### PR TITLE
Patch to support '=' chars in Message-ID

### DIFF
--- a/search.c
+++ b/search.c
@@ -960,7 +960,7 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
       }
 
       equal = strchr(word, '=');
-      if (equal) {
+      if (equal && !do_msgid) {
         *equal = 0;
         max_errors = atoi(equal + 1);
         /* Extend this to do anchoring etc */


### PR DESCRIPTION
Message IDs are allowed to have '=' chars in them (see the definition of atext in RFC2822/5322), but the substring match character conflicts.  After the discussion in the "Escape special matching characters?" thread on the user's list (Message-ID 1280859332.5c468@strabo.loghyr.farmgate), I decided to take a look at the code.  The change to make "m:" queries ignore '=' was trivial, so here's the patch for your consideration.
