### PR TITLE
IMAP support in mairix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -75,6 +75,7 @@ nvp.o : nvpscan.h
 
 mairix.o : imapinterface.h
 db.o : imapinterface.h
+search.o : imapinterface.h
 
 imap.o : imap.c imap.h
 imapinterface.o : imapinterface.c imapinterface.h imap.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -50,7 +50,7 @@ docdir=$(DESTDIR)@docdir@
 OBJ = mairix.o db.o rfc822.o tok.o hash.o dirscan.o writer.o \
       reader.o search.o stats.o dates.o datescan.o mbox.o md5.o \
   	  fromcheck.o glob.o dumper.o expandstr.o dotlock.o \
-			nvp.o nvpscan.o
+			nvp.o nvpscan.o imap.o imapinterface.o
 
 all : mairix
 
@@ -72,6 +72,9 @@ nvpscan.c nvpscan.h : nvp.nfa ./dfasyn/dfasyn
 dates.o : datescan.h
 mbox.o : fromcheck.h
 nvp.o : nvpscan.h
+
+imap.o : imap.c imap.h
+imapinterface.o : imapinterface.c imapinterface.h imap.h
 
 version.h:
 	./mkversion

--- a/Makefile.in
+++ b/Makefile.in
@@ -73,6 +73,9 @@ dates.o : datescan.h
 mbox.o : fromcheck.h
 nvp.o : nvpscan.h
 
+mairix.o : imapinterface.h
+db.o : imapinterface.h
+
 imap.o : imap.c imap.h
 imapinterface.o : imapinterface.c imapinterface.h imap.h
 

--- a/configure
+++ b/configure
@@ -181,6 +181,30 @@ test_for_flex () {
 }
 #}}}
 
+#{{{ test_for_openssl
+test_for_openssl () {
+  cat > docheck.c <<EOF;
+#include <openssl/ssl.h>
+int main () {
+  SSL_load_error_strings();
+  SSL_library_init();
+  return 0;
+}
+EOF
+  echo "Test program is" 1>&5
+  cat docheck.c 1>&5
+  ${MYCC} ${MYCPPFLAGS} ${MYCFLAGS} ${MYLDFLAGS} -o docheck docheck.c -lssl -lcrypto 1>&5 2>&1
+  if [ $? -eq 0 ]
+  then
+    result=0
+  else
+    result=1
+  fi
+  rm -f docheck.c docheck
+  echo $result
+}
+#}}}
+
 #{{{ usage
 usage () {
   cat <<EOF;
@@ -341,6 +365,15 @@ if [ `test_for_flex` -eq 0 ]; then
 else
   printf "No\n";
   exit 1;
+fi
+
+printf "Checking for OpenSSL : "
+if [ `test_for_openssl` -eq 0 ]; then
+  printf "Yes\n";
+  DEFS="${DEFS} -DUSE_OPENSSL"
+  LIBS="${LIBS} -lssl -lcrypto"
+else
+  printf "No (disabled IMAP STARTTLS support)\n";
 fi
 
 #{{{ Determine version number of the program.

--- a/db.c
+++ b/db.c
@@ -844,7 +844,7 @@ static void find_threading(struct database *db)/*{{{*/
   return;
 }
 /*}}}*/
-static int lookup_msgpath(struct msgpath *sorted_paths, int n_msgs, char *key)/*{{{*/
+static int lookup_msgpath(struct msgpath *sorted_paths, int n_msgs, char *key, enum message_type type)/*{{{*/
 {
   /* Implement bisection search */
  int l, h, m, r;
@@ -853,7 +853,13 @@ static int lookup_msgpath(struct msgpath *sorted_paths, int n_msgs, char *key)/*
  while (h > l) {
    m = (h + l) >> 1;
    /* Should only get called on 'file' type messages - TBC */
-   r = strcmp(sorted_paths[m].src.mpf.path, key);
+   if (sorted_paths[m].type < type) {
+     r = -1;
+   } else if (sorted_paths[m].type > type) {
+     r = 1;
+   } else {
+     r = strcmp(sorted_paths[m].src.mpf.path, key);
+   }
    if (r == 0) break;
    if (l == m) return -1;
    if (r > 0) h = m;
@@ -929,7 +935,7 @@ int update_database(struct database *db, struct msgpath *sorted_paths, int n_msg
   for (i=0; i<db->n_msgs; i++) {
     switch (db->type[i]) {
       case MTY_FILE:
-        matched_index = lookup_msgpath(sorted_paths, n_msgs, db->msgs[i].src.mpf.path);
+        matched_index = lookup_msgpath(sorted_paths, n_msgs, db->msgs[i].src.mpf.path, MTY_FILE);
         if (matched_index >= 0) {
           if (do_fast_index) {
             /* Assume the presence of a matching path is good enough without

--- a/dirscan.c
+++ b/dirscan.c
@@ -348,21 +348,6 @@ static void scan_directory(char *folder_base, char *this_folder, enum folder_typ
 }
 /*}}}*/
 #endif
-static int message_compare(const void *a, const void *b)/*{{{*/
-{
-  /* FIXME : Is this a sensible way to do this with mbox messages in the picture? */
-  struct msgpath *aa = (struct msgpath *) a;
-  struct msgpath *bb = (struct msgpath *) b;
-  if (aa->type < bb->type) return -1;
-  if (aa->type > bb->type) return 1;
-  return strcmp(aa->src.mpf.path, bb->src.mpf.path);
-}
-/*}}}*/
-static void sort_message_list(struct msgpath_array *arr)/*{{{*/
-{
-  qsort(arr->paths, arr->n, sizeof(struct msgpath), message_compare);
-}
-/*}}}*/
 /*{{{ void build_message_list */
 void build_message_list(char *folder_base, char *folders, enum folder_type ft,
     struct msgpath_array *msgs,
@@ -392,7 +377,6 @@ void build_message_list(char *folder_base, char *folders, enum folder_type ft,
 
   if (paths) free(paths);
 
-  sort_message_list(msgs);
   return;
 }
 /*}}}*/

--- a/dirscan.c
+++ b/dirscan.c
@@ -35,7 +35,6 @@ struct msgpath_array *new_msgpath_array(void)/*{{{*/
   struct msgpath_array *result;
   result = new(struct msgpath_array);
   result->paths = NULL;
-  result->type = NULL;
   result->n = 0;
   result->max = 0;
   return result;
@@ -46,7 +45,7 @@ void free_msgpath_array(struct msgpath_array *x)/*{{{*/
   int i;
   if (x->paths) {
     for (i=0; i<x->n; i++) {
-      switch (x->type[i]) {
+      switch (x->paths[i].type) {
         case MTY_FILE:
           free(x->paths[i].src.mpf.path);
           break;
@@ -56,7 +55,6 @@ void free_msgpath_array(struct msgpath_array *x)/*{{{*/
           break;
       }
     }
-    free(x->type);
     free(x->paths);
   }
   free(x);
@@ -67,9 +65,8 @@ static void add_file_to_list(char *x, struct msgpath_array *arr) {/*{{{*/
   if (arr->n == arr->max) {
     arr->max += 1024;
     arr->paths = grow_array(struct msgpath,    arr->max, arr->paths);
-    arr->type  = grow_array(enum message_type, arr->max, arr->type);
   }
-  arr->type[arr->n] = MTY_FILE;
+  arr->paths[arr->n].type = MTY_FILE;
   arr->paths[arr->n].src.mpf.path = y;
   ++arr->n;
   return;
@@ -356,7 +353,8 @@ static int message_compare(const void *a, const void *b)/*{{{*/
   /* FIXME : Is this a sensible way to do this with mbox messages in the picture? */
   struct msgpath *aa = (struct msgpath *) a;
   struct msgpath *bb = (struct msgpath *) b;
-  /* This should only get called on 'file' type messages - TBC! */
+  if (aa->type < bb->type) return -1;
+  if (aa->type > bb->type) return 1;
   return strcmp(aa->src.mpf.path, bb->src.mpf.path);
 }
 /*}}}*/

--- a/dirscan.c
+++ b/dirscan.c
@@ -47,6 +47,7 @@ void free_msgpath_array(struct msgpath_array *x)/*{{{*/
     for (i=0; i<x->n; i++) {
       switch (x->paths[i].type) {
         case MTY_FILE:
+        case MTY_IMAP:
           free(x->paths[i].src.mpf.path);
           break;
         case MTY_MBOX:

--- a/dumper.c
+++ b/dumper.c
@@ -99,6 +99,10 @@ void dump_database(char *filename)
         printf("FILE %s, size=%d, tid=%d",
                db->data + db->path_offsets[i], db->size_table[i], db->tid_table[i]);
         break;
+      case DB_MSG_IMAP:
+        printf("IMAP %s, tid=%d",
+               db->data + db->path_offsets[i], db->tid_table[i]);
+        break;
       case DB_MSG_MBOX:
         {
           unsigned int mbix, msgix;

--- a/imap.c
+++ b/imap.c
@@ -1,0 +1,1269 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <netdb.h>
+#include <fcntl.h>
+#include <time.h>
+#include <poll.h>
+#include <signal.h>
+#include <sys/wait.h>
+#ifdef USE_OPENSSL
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#endif
+#include "imap.h"
+
+struct imap_ll {
+	int w_socket;
+	int r_socket;
+	time_t timeout_time;
+	char buffer[1024];
+	char *bufferp;
+	size_t buffer_left;
+	int current_tag_number;
+#ifdef USE_OPENSSL
+	SSL *ssl;
+#endif
+
+	char *selected_folder;
+	size_t selected_folder_namelen;
+	char *selected_folder_uidvalidity;
+	int selected_folder_writable;
+	long selected_folder_exists;
+};
+
+struct imap_ll *
+imap_ll_connect(const char *host, const char *port)
+{
+struct imap_ll *ll;
+struct addrinfo hints, *res, *res0;
+int error;
+int s;
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = PF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	error = getaddrinfo(host, port, &hints, &res0);
+	if (error) {
+		fprintf(stderr, "getaddrinfo \"%s\":\"%s\": %s\n",
+			host, port, gai_strerror(error)
+		);
+		return NULL;
+	}
+	s = -1;
+	for (res = res0; res; res = res->ai_next) {
+		s = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+		if (s < 0) {
+			fprintf(stderr, "socket \"%s\":\"%s\": %s\n",
+				host, port, strerror(errno)
+			);
+			continue;
+		}
+		if (connect(s, res->ai_addr, res->ai_addrlen) < 0) {
+			fprintf(stderr, "connect \"%s\":\"%s\": %s\n",
+				host, port, strerror(errno)
+			);
+			close(s);
+			s = -1;
+			continue;
+		}
+		break;
+	}
+	if (s == -1) {
+		if (!res0) {
+			fprintf(stderr, "server \"%s\":\"%s\": no available addresses\n",
+				host, port
+			);
+		}
+		return NULL;
+	}
+
+	ll = malloc(sizeof(*ll));
+	if (!ll) {
+		fprintf(stderr, "malloc failed\n");
+		close(s);
+		return NULL;
+	}
+	memset(ll, 0, sizeof(*ll));
+	ll->w_socket = ll->r_socket = s;
+	ll->current_tag_number = -1;
+#ifdef USE_OPENSSL
+	ll->ssl = NULL;
+#endif
+	fcntl(s, F_SETFL, O_NONBLOCK);
+
+	return ll;
+}
+
+struct imap_ll *
+imap_ll_pipe_connect(const char *cmd)
+{
+struct imap_ll *ll;
+pid_t child;
+int status;
+int r[2], w[2];
+
+	if (pipe(&(r[0])) < 0) {
+		fprintf(stderr, "pipe1 failed\n");
+		return NULL;
+	}
+	if (pipe(&(w[0])) < 0) {
+		fprintf(stderr, "pipe2 failed\n");
+		close(r[0]);
+		close(r[1]);
+		return NULL;
+	}
+	if ((child = fork()) < 0) {
+		fprintf(stderr, "fork failed\n");
+		return NULL;
+	}
+	if (child == 0) {
+		close(r[0]);
+		close(w[1]);
+		if (r[1] != STDOUT_FILENO) {
+			dup2(r[1], STDOUT_FILENO);
+			close(r[1]);
+		}
+		if (w[0] != STDIN_FILENO) {
+			dup2(w[0], STDIN_FILENO);
+			close(w[0]);
+		}
+		execl("/bin/sh", "sh", "-c", cmd, NULL);
+		_exit(1);
+	}
+	close(r[1]);
+	close(w[0]);
+
+	ll = malloc(sizeof(*ll));
+	if (!ll) {
+		fprintf(stderr, "malloc failed\n");
+		close(r[0]);
+		close(w[1]);
+		kill(child, SIGTERM);
+		waitpid(child, &status, 0);
+		return NULL;
+	}
+	memset(ll, 0, sizeof(*ll));
+	ll->w_socket = w[1];
+	ll->r_socket = r[0];
+	ll->current_tag_number = -1;
+#ifdef USE_OPENSSL
+	ll->ssl = NULL;
+#endif
+	fcntl(w[1], F_SETFL, O_NONBLOCK);
+	fcntl(r[0], F_SETFL, O_NONBLOCK);
+
+	return ll;
+}
+
+void
+imap_ll_timeout(struct imap_ll *ll, int seconds)
+{
+	ll->timeout_time = time(NULL) + seconds;
+}
+
+static struct imap_ll_tokenlist *
+mktoken(int type, char *leaf, size_t len)
+{
+struct imap_ll_tokenlist *tl;
+
+	tl = malloc(sizeof(*tl));
+	if (!tl) {
+		fprintf(stderr, "imap_ll mktoken: malloc failed (fatal)\n");
+		sleep(1);
+		_exit(0);
+	}
+	tl->type = type;
+	tl->first = tl->last = NULL;
+	tl->parent = NULL;
+	tl->leaf = leaf;
+	tl->leaflen = len;
+	if (leaf) leaf[len] = 0;
+	return tl;
+}
+
+static void
+growlist(struct imap_ll_tokenlist **nodep, struct imap_ll_tokenlist *tl)
+{
+	if ((*nodep)->last) {
+		(*nodep)->last->next = tl;
+	} else {
+		(*nodep)->first = tl;
+	}
+	(*nodep)->last = tl;
+	tl->parent = *nodep;
+	tl->next = NULL;
+	if (!(tl->leaf)) {
+		*nodep = tl;
+	}
+}
+
+void
+imap_ll_freeline(struct imap_ll_tokenlist *t)
+{
+struct imap_ll_tokenlist *t2;
+
+	if (t) {
+		if (t->leaf) free(t->leaf);
+		for (t2 = t->first; t2; t2 = t2->next) {
+			imap_ll_freeline(t2);
+		}
+		free(t);
+	}
+}
+
+#define MKPRETOKEN(alloc_size) { \
+	curtoken = malloc((alloc_size) + 1); \
+	if (!curtoken) { \
+		fprintf(stderr, "imap_ll_waitline(%d): malloc failed (fatal)\n", (alloc_size)); \
+		sleep(1); \
+		_exit(0); \
+	} \
+	curtoken_now = 0; \
+	curtoken_max = (alloc_size); \
+}
+
+struct imap_ll_tokenlist *
+imap_ll_waitline(struct imap_ll *ll)
+{
+int timeout, n;
+#ifdef USE_OPENSSL
+int ret2;
+#endif
+char cur;
+struct imap_ll_tokenlist *line = NULL;
+struct imap_ll_tokenlist *node = NULL;
+int linestate = 0;
+int recv_tag;
+char *curtoken = NULL;
+size_t curtoken_now;
+size_t curtoken_max;
+struct pollfd pfd;
+
+	for (;;) {
+		while (ll->buffer_left) {
+			cur = *(ll->bufferp);
+			ll->bufferp++;
+			ll->buffer_left--;
+			if ((cur == 10) && (linestate < 7)) {
+				if (curtoken && (linestate == 4)) {
+					growlist(&node, mktoken(TLTYPE_ATOM, curtoken, curtoken_now));
+				} else if (curtoken) {
+					free(curtoken);
+				}
+				curtoken = NULL;
+				return line;
+			}
+			switch (linestate) {
+				case 0:
+					/* expect start of line */
+					if (cur == '*') {
+						linestate = 1;
+					} else if (cur == 't') {
+						linestate = 2;
+						recv_tag = 0;
+					} else if (cur == '+') {
+						line = mktoken(TLTYPE_CONTINUATION, NULL, 0);
+						linestate = 3;
+					} else {
+						linestate = 3;
+					}
+					break;
+				case 1:
+					/* expect space after untagged prefix */
+					if (cur == ' ') {
+						node = line = mktoken(TLTYPE_UNTAGGED, NULL, 0);
+						linestate = 4;
+					} else {
+						linestate = 3;
+					}
+					break;
+				case 2:
+					/* expect tag */
+					if (cur == ' ') {
+						if (recv_tag == ll->current_tag_number) {
+							node = line = mktoken(TLTYPE_TAGGED, NULL, 0);
+							linestate = 4;
+						} else {
+							/* wrong tag */
+							linestate = 3;
+						}
+					} else if ((cur >= '0') && (cur <= '9')) {
+						recv_tag *= 10;
+						recv_tag += cur - '0';
+					} else {
+						linestate = 3;
+					}
+					break;
+				case 3:
+					/* error -- discard until end of line */
+					break;
+				case 4:
+					/* looking for start of next "thing" */
+					if (cur == 34) {
+						linestate = 5;
+						MKPRETOKEN(50);
+					} else if (cur == 123) {
+						linestate = 6;
+						recv_tag = 0;
+					} else if (
+						(cur == 91) /* square bracket */ &&
+						(line == node) /* top level */ &&
+						(line->first) /* not first in list */ &&
+						/* list has exactly 1 */
+						(line->first == line->last)
+					) {
+						growlist(&node, mktoken(TLTYPE_SQLIST, NULL, 0));
+					} else if (cur == 40) {
+						growlist(&node, mktoken(TLTYPE_LIST, NULL, 0));
+					} else if ((
+						(node->type == TLTYPE_LIST) &&
+						(cur == 41)
+					) || (
+						(node->type == TLTYPE_SQLIST) &&
+						(cur == 93)
+					)) {
+						if (curtoken) {
+							growlist(&node, mktoken(TLTYPE_ATOM, curtoken, curtoken_now));
+							curtoken = NULL;
+						}
+						node = node->parent;
+					} else if (
+	
+						(cur == ' ') ||
+						(cur == 9) ||
+						(cur == 13)
+					) {
+						if (curtoken) {
+							growlist(&node, mktoken(TLTYPE_ATOM, curtoken, curtoken_now));
+							curtoken = NULL;
+						}
+					} else {
+						if (!curtoken) {
+							MKPRETOKEN(25);
+						}
+token_extend:
+						if (curtoken_now >= curtoken_max) {
+							curtoken_max *= 2;
+							curtoken = realloc(curtoken, curtoken_max + 1);
+							if (!curtoken) {
+								fprintf(stderr, "imap_ll_waitline(size=%d): malloc failed (fatal)\n", (int)curtoken_max);
+								sleep(1);
+								_exit(0);
+							}
+						}
+						curtoken[curtoken_now++] = cur;
+					}
+					break;
+				case 5:
+					/* quoted string */
+					if (cur == 34) {
+						growlist(&node, mktoken(TLTYPE_STRING, curtoken, curtoken_now));
+						curtoken = NULL;
+						linestate = 4;
+					} else {
+						goto token_extend;
+					}
+					break;
+				case 6:
+					/* literal count */
+					if (cur == 125) {
+						linestate = 7;
+					} else if ((cur >= '0') && (cur <= '9')) {
+						recv_tag *= 10;
+						recv_tag += cur - '0';
+					} else {
+						linestate = 3;
+					}
+					break;
+				case 7:
+					/* CRLF after {nn} */
+					if (cur == 13) break;
+					if (cur != 10) {
+						linestate = 3;
+					}
+					MKPRETOKEN(recv_tag);
+					if (recv_tag == 0) {
+						growlist(&node, mktoken(TLTYPE_STRING, curtoken, curtoken_now));
+						curtoken = NULL;
+						linestate = 4;
+					} else {
+						linestate = 8;
+					}
+					break;
+				case 8:
+					/* literal contents */
+					curtoken[curtoken_now++] = cur;
+					if (curtoken_now == curtoken_max) {
+						growlist(&node, mktoken(TLTYPE_STRING, curtoken, curtoken_now));
+						curtoken = NULL;
+						linestate = 4;
+					}
+					break;
+			}
+		}
+#ifdef USE_OPENSSL
+		if (ll->ssl) {
+			while ((n = SSL_read(ll->ssl, &((ll->buffer)[0]), sizeof(ll->buffer))) <= 0) {
+				ret2 = SSL_get_error(ll->ssl, n);
+				if ((ret2 == SSL_ERROR_WANT_READ) || (ret2 == SSL_ERROR_WANT_WRITE)) {
+					if (ret2 == SSL_ERROR_WANT_READ) {
+						pfd.fd = ll->r_socket;
+						pfd.events = POLLIN;
+					} else {
+						pfd.fd = ll->w_socket;
+						pfd.events = POLLOUT;
+					}
+					timeout = ll->timeout_time - time(NULL);
+					if (timeout < 0) timeout = 0;
+					if ((n = poll(&pfd, 1, timeout*1000)) < 0) {
+						if (errno == EINTR) continue;
+						goto pollerr;
+					}
+					if (n == 0) goto polltimeout;
+				} else {
+					ERR_print_errors_fp(stderr);
+					imap_ll_freeline(line);
+					return NULL;
+				}
+			}
+		} else {
+#endif
+			pfd.fd = ll->r_socket;
+			pfd.events = POLLIN;
+repoll:
+			timeout = ll->timeout_time - time(NULL);
+			if (timeout < 0) timeout = 0;
+			if ((n = poll(&pfd, 1, timeout*1000)) < 0) {
+				if (errno == EINTR) goto repoll;
+#ifdef USE_OPENSSL
+pollerr:
+#endif
+				fprintf(stderr, "imap_ll_waitline: poll: %s\n", strerror(errno));
+				imap_ll_freeline(line);
+				return NULL;
+			}
+			if (n == 0) {
+#ifdef USE_OPENSSL
+polltimeout:
+#endif
+				fprintf(stderr, "imap_ll_waitline: timeout\n");
+				imap_ll_freeline(line);
+				return NULL;
+			}
+			if ((n = read(ll->r_socket, &((ll->buffer)[0]), sizeof(ll->buffer))) < 0) {
+				if (errno == EAGAIN) continue;
+				if (errno == EINTR) continue;
+				fprintf(stderr, "imap_ll_waitline: read: %s\n", strerror(errno));
+				imap_ll_freeline(line);
+				return NULL;
+			}
+			if (n == 0) {
+				fprintf(stderr, "imap_ll_waitline: read: EOF\n");
+				imap_ll_freeline(line);
+				return NULL;
+			}
+#ifdef USE_OPENSSL
+		}
+#endif
+		ll->buffer_left = n;
+		ll->bufferp = &((ll->buffer)[0]);
+	}
+}
+
+/* this may overestimate the size a bit */
+static size_t
+string_len(struct imap_ll_tokenlist *t)
+{
+size_t result;
+
+	switch (t->type) {
+		case TLTYPE_UNTAGGED:
+			result = 2;
+			break;
+		case TLTYPE_TAGGED:
+			result = 15;
+			break;
+		case TLTYPE_LIST:
+		case TLTYPE_SQLIST:
+			result = 2;
+			break;
+		case TLTYPE_ATOM:
+			result = t->leaflen;
+			break;
+		case TLTYPE_STRING:
+			/* worst case is if it's sent as a literal */
+			result = 20 + t->leaflen;
+			break;
+		case TLTYPE_CONTINUATION:
+			/* shouldn't be used */
+			result = 2;
+			break;
+		case TLTYPE_POP:
+		case TLTYPE_END:
+		case TLTYPE_SUB:
+		default:
+			result = 0;
+	}
+	for (t = t->first; t; t = t->next) {
+		result++;
+		result += string_len(t);
+	}
+	return result;
+}
+
+static char *
+format_cmd(char *out, struct imap_ll *ll, struct imap_ll_tokenlist *t)
+{
+int i;
+char close = 0;
+
+	switch (t->type) {
+		case TLTYPE_UNTAGGED:
+			*(out++) = '*';
+			*(out++) = ' ';
+		case TLTYPE_TAGGED:
+			out += sprintf(out, "t%d ", ++(ll->current_tag_number));
+			break;
+		case TLTYPE_LIST:
+			*(out++) = '('; close = ')';
+			break;
+		case TLTYPE_SQLIST:
+			*(out++) = '['; close = ']';
+			break;
+		case TLTYPE_ATOM:
+			memcpy(out, t->leaf, t->leaflen);
+			out += t->leaflen;
+			break;
+		case TLTYPE_STRING:
+			for (i = 0; i < t->leaflen; i++) {
+				if (
+					(t->leaf[i] < 32) ||
+					(t->leaf[i] == 34) ||
+					(t->leaf[i] > 126)
+				) break;
+			}
+			if (i < t->leaflen) {
+				/* send as litteral */
+				out += sprintf(out, "{%d+}\015\012", (int)(t->leaflen));
+				memcpy(out, t->leaf, t->leaflen);
+				out += t->leaflen;
+			} else {
+				/* send as regular string */
+				*(out++) = 34;
+				memcpy(out, t->leaf, t->leaflen);
+				out += t->leaflen;
+				*(out++) = 34;
+			}
+			break;
+		case TLTYPE_CONTINUATION:
+			*(out++) = '+';
+			*(out++) = ' ';
+			break;
+		case TLTYPE_END:
+		case TLTYPE_POP:
+		case TLTYPE_SUB:
+			break;
+	}
+	i = 0;
+	for (t = t->first; t; t = t->next) {
+		if (i) {
+			*(out++) = ' ';
+		} else {
+			i = 1;
+		}
+		out = format_cmd(out, ll, t);
+	}
+	if (close) {
+		*(out++) = close;
+	}
+	return out;
+}
+
+static int
+imap_ll_write(struct imap_ll *ll, const char *p, const char *cmdend)
+{
+size_t len;
+struct pollfd pfd;
+int ctimeout, n;
+#ifdef USE_OPENSSL
+int ret2;
+
+	if (ll->ssl) {
+		while (p < cmdend) {
+			n = SSL_write(ll->ssl, p, cmdend-p);
+			if (n > 0) {
+				p += n;
+			} else {
+				ret2 = SSL_get_error(ll->ssl, n);
+				if ((ret2 == SSL_ERROR_WANT_READ) || (ret2 == SSL_ERROR_WANT_WRITE)) {
+					if (ret2 == SSL_ERROR_WANT_READ) {
+						pfd.fd = ll->r_socket;
+						pfd.events = POLLIN;
+					} else {
+						pfd.fd = ll->w_socket;
+						pfd.events = POLLOUT;
+					}
+					ctimeout = ll->timeout_time - time(NULL);
+					if (ctimeout < 0) ctimeout = 0;
+					if ((n = poll(&pfd, 1, ctimeout*1000)) < 0) {
+						if (errno == EINTR) continue;
+						goto pollerr;
+					}
+					if (n == 0) goto polltimeout;
+				} else {
+					ERR_print_errors_fp(stderr);
+					return 0;
+				}
+			}
+		}
+	} else {
+#endif
+		pfd.fd = ll->w_socket;
+		pfd.events = POLLOUT;
+		while (p < cmdend) {
+repoll:
+			ctimeout = ll->timeout_time - time(NULL);
+			if (ctimeout < 0) ctimeout = 0;
+			if ((n = poll(&pfd, 1, ctimeout*1000)) < 0) {
+				if (errno == EINTR) goto repoll;
+#ifdef USE_OPENSSL
+pollerr:
+#endif
+				fprintf(stderr, "imap_ll_command: poll: %s\n", strerror(errno));
+				return 0;
+			}
+			if (n == 0) {
+#ifdef USE_OPENSSL
+polltimeout:
+#endif
+				fprintf(stderr, "imap_ll_command: timeout\n");
+				return 0;
+			}
+			len = write(ll->w_socket, p, cmdend-p);
+			if (len < 0) {
+				if (errno == EAGAIN) continue;
+				if (errno == EINTR) continue;
+				fprintf(stderr, "imap_ll_command: write: %s\n", strerror(errno));
+				return 0;
+			} else if (len == 0) {
+				fprintf(stderr, "imap_ll_command: short write\n");
+				return 0;
+			}
+			p += len;
+		}
+#ifdef USE_OPENSSL
+	}
+#endif
+	return 1;
+}
+
+struct imap_ll_tokenlist *
+imap_ll_command(struct imap_ll *ll, struct imap_ll_tokenlist *cmd, int timeout)
+{
+size_t len;
+char *cmds, *cmdend;
+struct imap_ll_tokenlist *result, *cur;
+
+	len = string_len(cmd);
+	cmds = malloc(len+1);
+	if (!cmds) {
+		fprintf(stderr, "imap_ll_command: malloc failed\n");
+		return NULL;
+	}
+	cmdend = format_cmd(cmds, ll, cmd);
+	*(cmdend++) = 13;
+	*(cmdend++) = 10;
+	imap_ll_timeout(ll, timeout);
+	if (!imap_ll_write(ll, cmds, cmdend)) {
+		free(cmds);
+		return NULL;
+	}
+	free(cmds);
+	result = mktoken(TLTYPE_LIST, NULL, 0);
+	for (;;) {
+		if (!(cur = imap_ll_waitline(ll))) {
+			imap_ll_freeline(result);
+			return NULL;
+		}
+		cur->parent = result;
+		cur->next = NULL;
+		if (result->first) {
+			result->last->next = cur;
+		} else {
+			result->first = cur;
+		}
+		result->last = cur;
+
+		if (cur->type == TLTYPE_TAGGED) {
+			cur->next = NULL;
+			return result;
+		}
+        }
+}
+
+void
+imap_ll_logout(struct imap_ll *ll)
+{
+size_t len;
+struct imap_ll_tokenlist *cur;
+char cmd[25];
+
+	len = sprintf(cmd, "t%d LOGOUT\015\012", ++(ll->current_tag_number));
+	imap_ll_timeout(ll, 5);
+	if (!imap_ll_write(ll, cmd, cmd+len)) return;
+	imap_ll_timeout(ll, 5);
+	for (;;) {
+		if (!(cur = imap_ll_waitline(ll))) {
+			return;
+		}
+		if (cur->type == TLTYPE_TAGGED) {
+			break;
+		}
+		imap_ll_freeline(cur);
+	}
+	imap_ll_freeline(cur);
+}
+
+struct imap_ll_tokenlist *
+imap_ll_build(enum imap_ll_tltype maintype, ...)
+{
+va_list ap;
+struct imap_ll_tokenlist *top = NULL;
+struct imap_ll_tokenlist *cur = NULL;
+struct imap_ll_tokenlist *l;
+char *s;
+size_t slen;
+int descend;
+enum imap_ll_tltype next_type = maintype;
+
+	va_start(ap, maintype);
+	for (;;) {
+		switch (next_type) {
+			default:
+			case TLTYPE_END:
+				va_end(ap);
+				return top;
+			case TLTYPE_SUB:
+				l = va_arg(ap, struct imap_ll_tokenlist *);
+				descend = 0;
+				break;
+			case TLTYPE_ATOM:
+			case TLTYPE_STRING:
+				s = va_arg(ap, char *);
+				slen = va_arg(ap, size_t);
+				if (slen == -1) slen = strlen(s);
+				l = malloc(sizeof(*l));
+				if (!l) {
+nomem:
+					fprintf(stderr, "imap_ll_build: malloc failure\n");
+					imap_ll_freeline(top);
+					va_end(ap);
+					return NULL;
+				}
+				l->type = next_type;
+				l->leaf = malloc(slen+1);
+				if (!(l->leaf)) {
+					free(l);
+					goto nomem;
+				}
+				memcpy(l->leaf, s, slen);
+				l->leaf[slen] = 0;
+				l->leaflen = slen;
+				descend = 0;
+				break;
+			case TLTYPE_TAGGED:
+			case TLTYPE_UNTAGGED:
+			case TLTYPE_LIST:
+			case TLTYPE_SQLIST:
+				l = malloc(sizeof(*l));
+				if (!l) goto nomem;
+				l->type = next_type;
+				l->leaf = NULL;
+				descend = 1;
+				break;
+			case TLTYPE_CONTINUATION:
+				l = malloc(sizeof(*l));
+				if (!l) goto nomem;
+				l->type = TLTYPE_CONTINUATION;
+				l->leaf = NULL;
+				descend = 0;
+				break;
+			case TLTYPE_POP:
+				break;
+		}
+		if (next_type == TLTYPE_POP) {
+			cur = cur->parent;
+		} else {
+			if (next_type != TLTYPE_SUB) l->first = l->last = NULL;
+			l->parent = cur;
+			l->next = NULL;
+			if (cur) {
+				if (cur->last) {
+					cur->last->next = l;
+					cur->last = l;
+				} else {
+					cur->first = cur->last = l;
+				}
+			} else {
+				top = cur = l;
+			}
+			if (descend) cur = l;
+		}
+		next_type = va_arg(ap, int);
+	}
+}
+
+void
+imap_ll_append(struct imap_ll_tokenlist *list, struct imap_ll_tokenlist *item)
+{
+	if (list->last) {
+		list->last->next = item;
+	} else {
+		list->first = item;
+	}
+	list->last = item;
+	item->parent = list;
+}
+
+const char *
+imap_ll_status(struct imap_ll_tokenlist *t)
+{
+	t = t->last->first;
+	if (!t) return "BAD";
+	if ((t->type) != TLTYPE_ATOM) return "BAD";
+	return t->leaf;
+}
+
+#ifdef USE_OPENSSL
+enum imap_ll_starttls_result
+imap_ll_starttls(struct imap_ll *ll, SSL_CTX *sslctx, const char *servername)
+{
+struct imap_ll_tokenlist *cmd, *l;
+const char *status;
+struct pollfd pfd;
+int ret, ret2, timeout;
+SSL *ssl;
+long vr;
+X509 *peer;
+size_t servernamelen, certnamelen;
+char buf[256];
+char buf2[256];
+
+	ssl = SSL_new(sslctx);
+	if (!ssl) {
+		ERR_print_errors_fp(stderr);
+	}
+
+	cmd = imap_ll_build(TLTYPE_TAGGED, TLTYPE_ATOM, "STARTTLS", (size_t)-1, TLTYPE_END);
+	if (!cmd) {
+		fprintf(stderr, "could not build STARTTLS command\n");
+		SSL_free(ll->ssl); ll->ssl = NULL;
+		return IMAP_LL_STARTTLS_FAILED_PROCEED;
+	}
+	l = imap_ll_command(ll, cmd, 5);
+        imap_ll_freeline(cmd);
+        status = imap_ll_status(l);
+        if (0 == strcmp(status, "NO")) {
+		fprintf(stderr, "STARTTLS not accepted by server\n");
+		imap_ll_freeline(l);
+		SSL_free(ll->ssl); ll->ssl = NULL;
+		return IMAP_LL_STARTTLS_FAILED_PROCEED;
+	} else if (0 != strcmp(status, "OK")) {
+		fprintf(stderr, "STARTTLS not understood by server\n");
+		imap_ll_freeline(l);
+		SSL_free(ll->ssl); ll->ssl = NULL;
+		return IMAP_LL_STARTTLS_FAILED_PROCEED;
+	}
+	imap_ll_freeline(l);
+
+	SSL_set_rfd(ssl, ll->r_socket);
+	SSL_set_wfd(ssl, ll->w_socket);
+
+	imap_ll_timeout(ll, 10);	/* reset clock */
+	for (;;) {
+		ret = SSL_connect(ssl);
+		if (ret == 1) break;
+		ret2 = SSL_get_error(ssl, ret);
+		if ((ret2 == SSL_ERROR_WANT_READ) || (ret2 == SSL_ERROR_WANT_WRITE)) {
+			if (ret2 == SSL_ERROR_WANT_READ) {
+				pfd.fd = ll->r_socket;
+				pfd.events = POLLIN;
+			} else {
+				pfd.fd = ll->w_socket;
+				pfd.events = POLLOUT;
+			}
+			timeout = ll->timeout_time - time(NULL);
+			if (timeout < 0) timeout = 0;
+			if ((ret = poll(&pfd, 1, timeout*1000)) < 0) {
+				if (errno == EINTR) continue;
+				fprintf(stderr, "STARTTLS poll error: %s\n", strerror(errno));
+				SSL_free(ssl);
+				return IMAP_LL_STARTTLS_FAILED;
+			}
+			if (ret == 0) {
+				fprintf(stderr, "STARTTLS timeout\n");
+				SSL_free(ssl);
+				return IMAP_LL_STARTTLS_FAILED;
+			}
+		} else {
+			ERR_error_string(ERR_get_error(), &(buf[0]));
+			fprintf(stderr, "STARTTLS: %s\n", buf);
+			SSL_free(ssl);
+			return IMAP_LL_STARTTLS_FAILED;
+		}
+	}
+	if ((vr = SSL_get_verify_result(ssl)) != X509_V_OK) {
+		fprintf(stderr, "STARTTLS: ceritifcate verification failed (%ld)\n", vr);
+certfail:
+		SSL_free(ssl);
+		return IMAP_LL_STARTTLS_FAILED_CERT;
+	}
+	if (!(peer = SSL_get_peer_certificate(ssl))) {
+		fprintf(stderr, "STARTTLS: no peer certificate?\n");
+		goto certfail;
+	}
+	if (X509_NAME_get_text_by_NID(X509_get_subject_name(peer), NID_commonName, buf, sizeof(buf)) == -1) {
+		fprintf(stderr, "STARTTLS: no common name in certificate?\n");
+		goto certfail;
+	}
+	if (!servername) goto certok; /* caller does not want us to check */
+	if (0 != strcasecmp(buf, servername)){
+		/* Certificate name does not match exactly.
+		   Check for a wildcard certificate name.
+		   The only valid form for certificate naming wildcards is
+		   an asterisk as the first character followed by any number
+		   of non-wild characters */
+		if (buf[0] == '*') {
+			servernamelen = strlen(servername);
+			certnamelen = strlen(buf+1);
+			if (
+				(servernamelen >= certnamelen) &&
+				(0 == strcasecmp(
+					buf+1,
+					servername + (servernamelen-certnamelen))
+				)
+			) {
+				goto certok;
+			}
+		}
+		snprintf(buf2, sizeof(buf2), "%s", servername);
+		fprintf(stderr, "STARTTLS: server name \"%s\" != certificate common name \"%s\"\n", buf2, buf);
+		goto certfail;
+	}
+
+certok:
+	ll->ssl = ssl;
+	return IMAP_LL_STARTTLS_SUCCESS;
+}
+#endif
+
+void
+imap_ll_pprint(struct imap_ll_tokenlist *t, int indent, FILE *out)
+{
+int plusindent = 0;
+int i;
+const char *close = NULL;
+
+	switch (t->type) {
+		case TLTYPE_UNTAGGED:
+			for (i = 0; i < indent; i++) fputc(9, out);
+			fprintf(out, "*\n");
+			break;
+		case TLTYPE_TAGGED:
+			break;
+		case TLTYPE_LIST:
+			plusindent = 1;
+			for (i = 0; i < indent; i++) fputc(9, out);
+			fprintf(out, "(\n"); close = ")\n";
+			break;
+		case TLTYPE_SQLIST:
+			plusindent = 1;
+			for (i = 0; i < indent; i++) fputc(9, out);
+			fprintf(out, "[\n"); close = "]\n";
+			break;
+		case TLTYPE_ATOM:
+		case TLTYPE_STRING:
+			for (i = 0; i < indent; i++) fputc(9, out);
+			if ((t->type) == TLTYPE_STRING) fputc(34, out);
+			for (i = 0; i < (t->leaflen); i++) {
+				if (
+					(t->leaf[i] >= ' ') &&
+					(t->leaf[i] < 127) &&
+					(t->leaf[i] != 34) &&
+					(t->leaf[i] != 92)
+				) {
+					fputc(t->leaf[i], out);
+				} else {
+					fprintf(out, "\\x%02x", t->leaf[i]);
+				}
+			}
+			if ((t->type) == TLTYPE_STRING) fputc(34, out);
+			fputc('\n', out);
+			break;
+		case TLTYPE_CONTINUATION:
+			for (i = 0; i < indent; i++) fputc(9, out);
+			fputs("+ \n", out);
+			break;
+		case TLTYPE_END:
+		case TLTYPE_POP:
+		case TLTYPE_SUB:
+			break;
+	}
+	indent += plusindent;
+	for (t = t->first; t; t = t->next) {
+		imap_ll_pprint(t, indent, out);
+	}
+	indent -= plusindent;
+	if (close) {
+		for (i = 0; i < indent; i++) fputc(9, out);
+		fputs(close, out);
+	}
+}
+
+static struct imap_ll_tokenlist *
+find_capability_list_from_greeting(struct imap_ll_tokenlist *l)
+{
+	if (
+		(!(l->first)) || (!(l->first->next)) ||
+		(l->first->next->type != TLTYPE_SQLIST) ||
+		(!(l->first->next->first)) ||
+		(!(l->first->next->first->leaf)) ||
+		(0 != strcmp(l->first->next->first->leaf, "CAPABILITY"))
+	) {
+		fprintf(stderr, "IMAP client cannot find capabilities list\n");
+		return NULL;
+	}
+	return l->first->next->first->next;
+}
+
+#ifdef USE_OPENSSL
+static struct imap_ll_tokenlist *
+find_capability_list_in_untagged_response(struct imap_ll_tokenlist *l)
+{
+	for (l = l->first; l; l = l->next) {
+		if (
+			((l->type) == TLTYPE_UNTAGGED) &&
+			((l->first->type) == TLTYPE_ATOM) &&
+			(0 == strcmp(l->first->leaf, "CAPABILITY"))
+		) return l->first->next;
+	}
+	fprintf(stderr, "IMAP client cannot find capabilities list\n");
+	return NULL;
+}
+
+static int
+have_capability(struct imap_ll_tokenlist *l, const char *cap)
+{
+	for (; l; l = l->next) {
+		if ((l->leaf) && (0 == strcmp(l->leaf, cap))) return 1;
+	}
+	return 0;
+}
+#endif
+
+static int
+need_capability(struct imap_ll_tokenlist *l, const char *cap)
+{
+	for (; l; l = l->next) {
+		if ((l->leaf) && (0 == strcmp(l->leaf, cap))) return 1;
+	}
+	fprintf(stderr, "IMAP server missing required capability %s\n", cap);
+	return 0;
+}
+
+enum imap_login_result
+imap_login(
+	struct imap_ll *ll,
+	const char *username, size_t username_len,
+	const char *password, size_t password_len
+#ifdef USE_OPENSSL
+	, SSL_CTX *sslctx, const char *servername
+#endif
+) {
+struct imap_ll_tokenlist *cmd, *result, *caps;
+const char *status;
+
+	imap_ll_timeout(ll, 60);
+	if (!(result = imap_ll_waitline(ll))) {
+		fprintf(stderr, "error reading IMAP server greeting\n");
+		return imap_login_error;
+	}
+
+	if (
+		(!(result->first)) ||
+		((result->first->type) != TLTYPE_ATOM)
+	) {
+		fprintf(stderr, "cannot parse IMAP server greeting\n");
+		imap_ll_freeline(result);
+		return imap_login_error;
+	}
+	if (0 == strcmp(result->first->leaf, "BYE")) {
+		imap_ll_freeline(result);
+		fprintf(stderr, "IMAP server rejected connection\n");
+		return imap_login_error;
+	} else if (0 == strcmp(result->first->leaf, "PREAUTH")) {
+		if (!(caps = find_capability_list_from_greeting(result))) {
+			return imap_login_error;
+		}
+		goto logged_in;
+	} else if (0 != strcmp(result->first->leaf, "OK")) {
+		fprintf(stderr, "IMAP server unacceptable greeting\n");
+		return imap_login_error;
+	}
+
+	if (!(caps = find_capability_list_from_greeting(result))) {
+		return imap_login_error;
+	}
+
+#ifdef USE_OPENSSL
+	if (have_capability(caps, "STARTTLS")) {
+		switch (imap_ll_starttls(ll, sslctx, servername)) {
+			case IMAP_LL_STARTTLS_FAILED_PROCEED:
+				break;
+			case IMAP_LL_STARTTLS_FAILED:
+			case IMAP_LL_STARTTLS_FAILED_CERT:
+				imap_ll_freeline(result);
+				return imap_login_error;
+			case IMAP_LL_STARTTLS_SUCCESS:
+				imap_ll_freeline(result);
+				cmd = imap_ll_build(
+					TLTYPE_TAGGED,
+					TLTYPE_ATOM, "CAPABILITY", (size_t)-1,
+					TLTYPE_END
+				);
+				result = imap_ll_command(ll, cmd, 10);
+				imap_ll_freeline(cmd);
+				if (!(caps = find_capability_list_in_untagged_response(result))) {
+					return imap_login_error;
+				}
+		}
+	}
+#endif
+
+	if (!need_capability(caps, "LITERAL+")) return imap_login_error;
+	if ((!username) || (!password)) {
+		fprintf(stderr, "IMAP login credentials are needed\n");
+		return imap_login_denied;
+	}
+	if (!need_capability(caps, "AUTH=PLAIN")) return imap_login_error;
+	imap_ll_freeline(result);
+	cmd = imap_ll_build(
+		TLTYPE_TAGGED,
+		TLTYPE_ATOM, "LOGIN", (size_t)-1,
+		TLTYPE_STRING, username, username_len,
+		TLTYPE_STRING, password, password_len,
+		TLTYPE_END
+	);
+	result = imap_ll_command(ll, cmd, 40);
+	imap_ll_freeline(cmd);
+	status = imap_ll_status(result);
+	if (0 == strcmp(status, "OK")) {
+		if (!(caps = find_capability_list_from_greeting(result->last))) {
+			return imap_login_error;
+		}
+logged_in:
+		if (!need_capability(caps, "LITERAL+")) return imap_login_error;
+		imap_ll_freeline(result);
+		return imap_login_ok;
+	} else if (0 == strcmp(status, "NO")) {
+		fprintf(stderr, "IMAP authentication failed\n");
+		imap_ll_freeline(result);
+		return imap_login_denied;
+	}
+	fprintf(stderr, "IMAP server did not understand login command\n");
+	imap_ll_freeline(result);
+	return imap_login_error;
+}
+
+const char *
+imap_select(
+	struct imap_ll *ll,
+	const char *foldername, size_t foldername_len,
+	int need_write, long *exists_p
+) {
+const char *command_name;
+struct imap_ll_tokenlist *cmd, *result, *l, *l2;
+char *uidvalidity = NULL;
+long exists = 0;
+
+	if (foldername_len == -1) foldername_len = strlen(foldername);
+	if (
+		(ll->selected_folder) &&
+		((ll->selected_folder_namelen) == foldername_len) &&
+		(0 == memcmp(ll->selected_folder, foldername, foldername_len)) &&
+		((!need_write) || (ll->selected_folder_writable))
+	) {
+		if (exists_p) *exists_p = ll->selected_folder_exists;
+		return ll->selected_folder_uidvalidity;
+	}
+
+	command_name = need_write ? "SELECT" : "EXAMINE";
+	cmd = imap_ll_build(
+		TLTYPE_TAGGED,
+		TLTYPE_ATOM, command_name, (size_t)-1,
+		TLTYPE_STRING, foldername, foldername_len,
+		TLTYPE_END
+	);
+	result = imap_ll_command(ll, cmd, 40);
+	imap_ll_freeline(cmd);
+
+	if (!result) {
+		fprintf(stderr, "unable to %s folder \"%s\": no response from IMAP server\n", command_name, foldername);
+		return NULL;
+	}
+	if (0 != strcmp(imap_ll_status(result), "OK")) {
+		fprintf(stderr, "unable to %s folder \"%s\":\n", command_name, foldername);
+		imap_ll_pprint(result, 0, stderr);
+		imap_ll_freeline(result);
+		return NULL;
+	}
+
+	for (l = result->first; l != result->last; l = l->next) {
+		/* Check if this is UIDVALIDITY */
+		l2 = l->first;
+		if (!l2) continue;
+		if (l2->type != TLTYPE_ATOM) continue;
+		if (0 == strcmp(l2->leaf, "OK")) {
+			l2 = l2->next;
+			if (!l2) continue;
+			if (l2->type != TLTYPE_SQLIST) continue;
+			l2 = l2->first;
+			if (!l2) continue;
+			if (l2->type != TLTYPE_ATOM) continue;
+			if (0 != strcmp(l2->leaf, "UIDVALIDITY")) continue;
+			l2 = l2->next;
+			if (!l2) continue;
+			if (l2->type != TLTYPE_ATOM) continue;
+			uidvalidity = l2->leaf;
+		} else {
+			if (!(l2->next)) continue;
+			if ((l2->next->type) != TLTYPE_ATOM) continue;
+			if (0 != strcmp(l2->next->leaf, "EXISTS")) continue;
+			exists = atol(l2->leaf);
+		}
+	}
+	if (!uidvalidity) {
+		fprintf(stderr, "no uidvalidity in EXAMINE response for folder \"%s\":\n", foldername);
+		imap_ll_pprint(result, 0, stderr);
+		imap_ll_freeline(result);
+		return NULL;
+	}
+
+	if (ll->selected_folder) free(ll->selected_folder);
+	if (ll->selected_folder_uidvalidity) free(ll->selected_folder_uidvalidity);
+	ll->selected_folder = malloc(foldername_len);
+	if (ll->selected_folder) {
+		memcpy(ll->selected_folder, foldername, foldername_len);
+	}
+	ll->selected_folder_namelen = foldername_len;
+	ll->selected_folder_uidvalidity = strdup(uidvalidity);
+	ll->selected_folder_writable = need_write;
+	ll->selected_folder_exists = exists;
+	if (exists_p) *exists_p = exists;
+	imap_ll_freeline(result);
+	return ll->selected_folder_uidvalidity;
+}

--- a/imap.c
+++ b/imap.c
@@ -838,6 +838,19 @@ imap_ll_status(struct imap_ll_tokenlist *t)
 	return t->leaf;
 }
 
+int
+imap_ll_is_trycreate(struct imap_ll_tokenlist *t)
+{
+	return (
+		(0 == strcmp(imap_ll_status(t), "NO")) &&
+		(t->last->first->next) &&
+		((t->last->first->next->type) == TLTYPE_SQLIST) &&
+		(t->last->first->next->first) &&
+		((t->last->first->next->first->type) == TLTYPE_ATOM) &&
+		(0 == strcmp(t->last->first->next->first->leaf, "TRYCREATE"))
+	);
+}
+
 #ifdef USE_OPENSSL
 enum imap_ll_starttls_result
 imap_ll_starttls(struct imap_ll *ll, SSL_CTX *sslctx, const char *servername)

--- a/imap.h
+++ b/imap.h
@@ -1,0 +1,81 @@
+#ifndef __IMAPLL_H__
+#define __IMAPLL_H__
+
+#ifdef USE_OPENSSL
+#include <openssl/ssl.h>
+#endif
+#include <poll.h>
+
+enum imap_ll_tltype {
+	TLTYPE_UNTAGGED = 1,
+	TLTYPE_TAGGED = 2,
+	TLTYPE_LIST = 3,
+	TLTYPE_SQLIST = 4,
+	TLTYPE_ATOM = 5,
+	TLTYPE_STRING = 6,
+	TLTYPE_CONTINUATION = 7,
+	/* the following only for imap_ll_build */
+	TLTYPE_END = 100,
+	TLTYPE_POP = 101,
+	TLTYPE_SUB = 102
+};
+
+struct imap_ll_tokenlist {
+	enum imap_ll_tltype type;
+	char *leaf;
+	size_t leaflen;
+	struct imap_ll_tokenlist *parent;
+	struct imap_ll_tokenlist *next;
+	/* children */
+	struct imap_ll_tokenlist *first;
+	struct imap_ll_tokenlist *last;
+};
+
+struct imap_ll *imap_ll_connect(const char *host, const char *port);
+struct imap_ll *imap_ll_pipe_connect(const char *command);
+void imap_ll_timeout(struct imap_ll *, int seconds);
+struct imap_ll_tokenlist *imap_ll_waitline(struct imap_ll *);
+void imap_ll_freeline(struct imap_ll_tokenlist *);
+struct imap_ll_tokenlist *imap_ll_build(enum imap_ll_tltype maintype, ...);
+void imap_ll_append(struct imap_ll_tokenlist *, struct imap_ll_tokenlist *);
+void imap_ll_pprint(struct imap_ll_tokenlist *, int indent, FILE *);
+struct imap_ll_tokenlist *imap_ll_command(struct imap_ll *, struct imap_ll_tokenlist *, int timeout);
+const char *imap_ll_status(struct imap_ll_tokenlist *);
+
+#ifdef USE_OPENSSL
+enum imap_ll_starttls_result {
+	IMAP_LL_STARTTLS_FAILED_PROCEED,	/* STARTTLS failed but session still OK */
+	IMAP_LL_STARTTLS_FAILED,	/* session must be closed */
+	IMAP_LL_STARTTLS_FAILED_CERT,	/* certificate problem (session must be closed) */
+	IMAP_LL_STARTTLS_SUCCESS	/* certificate problem (session must be closed) */
+};
+enum imap_ll_starttls_result imap_ll_starttls(struct imap_ll *, SSL_CTX *, const char *servername);
+#endif
+
+void imap_ll_logout(struct imap_ll *);
+
+enum imap_login_result {
+	imap_login_ok = 0,
+	imap_login_denied = 1,
+	imap_login_error = 2
+};
+
+enum imap_login_result
+imap_login(
+	struct imap_ll *,
+	const char *username, size_t username_len,
+	const char *password, size_t password_len
+#ifdef USE_OPENSSL
+	, SSL_CTX *, const char *servername
+#endif
+);
+
+/* returns the uidvalidity of the opened folder if successful */
+const char *imap_select(
+	struct imap_ll *,
+	const char *foldername, size_t foldername_len,
+	int need_write,
+	long *exists_p	/* optional, return number of messages which exist */
+);
+
+#endif

--- a/imap.h
+++ b/imap.h
@@ -41,6 +41,7 @@ void imap_ll_append(struct imap_ll_tokenlist *, struct imap_ll_tokenlist *);
 void imap_ll_pprint(struct imap_ll_tokenlist *, int indent, FILE *);
 struct imap_ll_tokenlist *imap_ll_command(struct imap_ll *, struct imap_ll_tokenlist *, int timeout);
 const char *imap_ll_status(struct imap_ll_tokenlist *);
+int imap_ll_is_trycreate(struct imap_ll_tokenlist *);
 
 #ifdef USE_OPENSSL
 enum imap_ll_starttls_result {

--- a/imapinterface.c
+++ b/imapinterface.c
@@ -1,0 +1,272 @@
+#include <stdio.h>
+#include <string.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include "imapinterface.h"
+#include "imap.h"
+#include "mairix.h"
+
+struct imap_ll *
+imap_start(const char *pipe, const char *server, const char *username, const char *password)
+{
+#ifdef USE_OPENSSL
+SSL_CTX *sslctx;
+#endif
+struct imap_ll *imapc;
+
+#ifdef USE_OPENSSL
+	SSL_load_error_strings();
+	SSL_library_init();
+	sslctx = SSL_CTX_new(SSLv23_client_method());
+	if (!sslctx) {
+		fprintf(stderr, "SSL_CTX_new failed\n");
+		ERR_print_errors_fp(stderr);
+		return NULL;
+	}
+	SSL_CTX_load_verify_locations(sslctx, NULL, "/etc/ssl/certs");
+	SSL_CTX_set_verify(sslctx, SSL_VERIFY_PEER, NULL);
+#endif
+
+	imapc = pipe ? imap_ll_pipe_connect(pipe) : imap_ll_connect(server, "143");
+	if (!imapc) return NULL;
+
+	switch (imap_login(
+		imapc, username, -1, password, -1
+#ifdef USE_OPENSSL
+		, sslctx, server
+#endif
+	)) {
+		case imap_login_error:
+		case imap_login_denied:
+			return NULL;
+		case imap_login_ok:
+			break;
+	}
+
+	return imapc;
+}
+
+static void
+add_imap_message_to_list(const char *folder, const char *uidvalidity, const char *uid, struct msgpath_array *arr)
+{
+char *pseudopath;
+
+	pseudopath = Malloc(strlen(folder) + strlen(uidvalidity) + strlen(uid) + 3);
+	sprintf(pseudopath, "%s:%s:%s", uidvalidity, uid, folder);
+
+	if (arr->n == arr->max) {
+		arr->max += 1024;
+		arr->paths = grow_array(struct msgpath,    arr->max, arr->paths);
+	}
+	arr->paths[arr->n].type = MTY_IMAP;
+	arr->paths[arr->n].src.mpf.path = pseudopath;
+	++arr->n;
+}
+
+static void
+scan_folder(struct imap_ll *imapc, const char *folder, struct msgpath_array *msgs)
+{
+struct imap_ll_tokenlist *cmd, *result, *l, *l2, *l3;
+const char *uidvalidity;
+char *uid;
+int deleted;
+long exists;
+
+	uidvalidity = imap_select(imapc, folder, -1, 0, &exists);
+	if (!uidvalidity) return;
+	if (exists < 1) return;
+
+	cmd = imap_ll_build(
+		TLTYPE_TAGGED,
+		TLTYPE_ATOM, "UID", (size_t)-1,
+		TLTYPE_ATOM, "FETCH", (size_t)-1,
+		TLTYPE_ATOM, "1:*", (size_t)-1,
+		TLTYPE_ATOM, "FLAGS", (size_t)-1,
+		TLTYPE_END
+	);
+	result = imap_ll_command(imapc, cmd, 40);
+	imap_ll_freeline(cmd);
+
+	if (!result) {
+		fprintf(stderr, "unable to FETCH in folder \"%s\": no response from IMAP server\n", folder);
+		return;
+	}
+	if (0 != strcmp(imap_ll_status(result), "OK")) {
+		fprintf(stderr, "unable to FETCH in folder \"%s\":\n", folder);
+		imap_ll_pprint(result, 0, stderr);
+		imap_ll_freeline(result);
+		return;
+	}
+
+	for (l = result->first; l != result->last; l = l->next) {
+		l2 = l->first;
+		if (!l2) continue;
+		if (l2->type != TLTYPE_ATOM) continue;	/* sequence */
+		l2 = l2->next;
+		if (l2->type != TLTYPE_ATOM) continue;
+		if (0 != strcmp(l2->leaf, "FETCH")) continue;
+		l2 = l2->next;
+		if (l2->type != TLTYPE_LIST) continue;
+		uid = NULL;
+		deleted = 0;
+		for (l2 = l2->first; l2 && (l2->next); l2 = l2->next) {
+			if (l2->type != TLTYPE_ATOM) continue;
+			if (0 == strcmp(l2->leaf, "UID")) {
+				l2 = l2->next;
+				if (l2->type != TLTYPE_ATOM) continue;
+				uid = l2->leaf;
+			} else if (0 == strcmp(l2->leaf, "FLAGS")) {
+				l2 = l2->next;
+				if (l2->type != TLTYPE_LIST) continue;
+				for (l3 = l2->first; l3; l3 = l3->next) {
+					if (l3->type != TLTYPE_ATOM) continue;
+					if (0 == strcmp(l3->leaf, "\\Deleted")) {
+						deleted = 1;
+					}
+				}
+			}
+		}
+		if (deleted) continue;
+		if (!uid) continue;
+		add_imap_message_to_list(folder, uidvalidity, uid, msgs);
+	}
+	imap_ll_freeline(result);
+}
+
+void
+build_imap_message_list(
+	const char *folders, struct msgpath_array *msgs,
+	struct globber_array *omit_globs, struct imap_ll *imapc
+)
+{
+char **folderlist;
+int n_folders;
+int i;
+
+	split_on_colons(folders, &n_folders, &folderlist);
+	for (i = 0; i < n_folders; i++) {
+		if (!is_globber_array_match(omit_globs, folderlist[i])) {
+			scan_folder(imapc, folderlist[i], msgs);
+		}
+	}
+}
+
+int
+imap_fetch_message_raw(
+	const char *pseudopath, struct imap_ll *imapc,
+	void (*callback)(const char *, size_t, void *), void *arg
+)
+{
+struct imap_ll_tokenlist *cmd, *result, *l, *l2;
+const char *uidvalidity, *uid, *folder, *p;
+size_t uidvalidity_len;
+size_t uid_len, raw_len, got_uid_len;
+const char *actual_uidvalidity, *got_uid, *got_raw;
+
+	/* first part is the uidvalidity */
+	uidvalidity = pseudopath;
+	p = strchr(pseudopath, ':');
+	if (!p) return 0;
+	uidvalidity_len = p-pseudopath;
+	uid = p+1;
+
+	/* second part is the uid */
+	p = strchr(uid, ':');
+	if (!p) return 0;
+	uid_len = p-uid;
+	folder = p+1;
+
+	actual_uidvalidity = imap_select(imapc, folder, -1, 0, NULL);
+	if (!actual_uidvalidity) return 0;
+
+	if (
+		(strlen(actual_uidvalidity) != uidvalidity_len) ||
+		(0 != memcmp(uidvalidity, actual_uidvalidity, uidvalidity_len))
+	) {
+		fprintf(stderr, "IMAP message \"%s\" cannot be loaded because UIDVALIDITY changed\n", pseudopath);
+		return 0;
+	}
+
+	cmd = imap_ll_build(
+		TLTYPE_TAGGED,
+		TLTYPE_ATOM, "UID", (size_t)-1,
+		TLTYPE_ATOM, "FETCH", (size_t)-1,
+		TLTYPE_ATOM, uid, uid_len,
+		TLTYPE_ATOM, "BODY.PEEK[]", (size_t)-1,
+		TLTYPE_END
+	);
+	result = imap_ll_command(imapc, cmd, 40);
+	imap_ll_freeline(cmd);
+
+	if (!result) {
+		fprintf(stderr, "unable to FETCH message \"%s\": no response from IMAP server\n", pseudopath);
+		return 0;
+	}
+	if (0 != strcmp(imap_ll_status(result), "OK")) {
+		fprintf(stderr, "unable to FETCH message \"%s\":\n", pseudopath);
+		imap_ll_pprint(result, 0, stderr);
+		imap_ll_freeline(result);
+		return 0;
+	}
+
+	for (l = result->first; l != result->last; l = l->next) {
+		l2 = l->first;
+		if (!l2) continue;
+		if (l2->type != TLTYPE_ATOM) continue;	/* sequence */
+		l2 = l2->next;
+		if (l2->type != TLTYPE_ATOM) continue;
+		if (0 != strcmp(l2->leaf, "FETCH")) continue;
+		l2 = l2->next;
+		if (l2->type != TLTYPE_LIST) continue;
+		got_uid = got_raw = NULL;
+		for (l2 = l2->first; l2 && (l2->next); l2 = l2->next) {
+			if (l2->type != TLTYPE_ATOM) continue;
+			if (0 == strcmp(l2->leaf, "UID")) {
+				l2 = l2->next;
+				if (l2->type != TLTYPE_ATOM) continue;
+				got_uid = l2->leaf;
+				got_uid_len = l2->leaflen;
+			} else if (0 == strcmp(l2->leaf, "BODY[]")) {
+				l2 = l2->next;
+				if (l2->type != TLTYPE_STRING) continue;
+				got_raw = l2->leaf;
+				raw_len = l2->leaflen;
+			}
+		}
+		if ((!got_uid) || (!got_raw)) continue;
+		if (got_uid_len != uid_len) continue;
+		if (0 != memcmp(got_uid, uid, got_uid_len)) continue;
+		callback(got_raw, raw_len, arg);
+		imap_ll_freeline(result);
+		return 1;
+	}
+	fprintf(stderr, "IMAP server did not return message \"%s\"\n", pseudopath);
+	imap_ll_freeline(result);
+	return 0;
+}
+
+struct make_rfc822_from_imap_s {
+	const char *pseudopath;
+	struct rfc822 *r;
+};
+
+static void
+callback822(const char *data, size_t len, void *arg)
+{
+struct make_rfc822_from_imap_s *s = (struct make_rfc822_from_imap_s *)arg;
+struct msg_src src;	/* assuming this is for error message presentation only! */
+
+	src.type = MS_FILE;
+	src.filename = (char *)(s->pseudopath);	/* XXX breaking "const" */
+	s->r = data_to_rfc822(&src, (char *)data /* XXX breaking "const" */, len, NULL);
+}
+
+struct rfc822 *
+make_rfc822_from_imap(const char *pseudopath, struct imap_ll *imapc)
+{
+struct make_rfc822_from_imap_s s;
+
+	s.pseudopath = pseudopath;
+	imap_fetch_message_raw(pseudopath, imapc, callback822, &s);
+	return s.r;
+}

--- a/imapinterface.h
+++ b/imapinterface.h
@@ -24,4 +24,8 @@ int imap_fetch_message_raw(
 struct rfc822 *
 make_rfc822_from_imap(const char *pseudopath, struct imap_ll *);
 
+void imap_clear_folder(struct imap_ll *, const char *);
+void imap_append_new_message(struct imap_ll *, const char *folder, const unsigned char *data, size_t len, int seen, int answered, int flagged);
+void imap_copy_message(struct imap_ll *, const char *pseudopath, const char *to_folder);
+
 #endif

--- a/imapinterface.h
+++ b/imapinterface.h
@@ -1,0 +1,27 @@
+#ifndef __IMAPMSG_H__
+#define __IMAPMSG_H__
+
+#include "mairix.h"
+
+struct imap_ll;
+
+/* set pipe OR server, not both */
+struct imap_ll *
+imap_start(const char *pipe, const char *server, const char *username, const char *password);
+
+void
+build_imap_message_list(const char *folders, struct msgpath_array *msgs, struct globber_array *omit_globs, struct imap_ll *);
+
+/* returns 1 on success, 0 otherwise */
+int imap_fetch_message_raw(
+	const char *pseudopath, struct imap_ll *imapc,
+	/* on success, calls this callback */
+	void (*callback)(const char *, size_t, void *), void *arg
+	/* after the callback returns, the pointer to the message
+	   data is no longer valid. */
+);
+
+struct rfc822 *
+make_rfc822_from_imap(const char *pseudopath, struct imap_ll *);
+
+#endif

--- a/mairix.1
+++ b/mairix.1
@@ -102,12 +102,18 @@ maildir
 MH (compatible with the MH folder formats used by xmh, sylpheed, claws-mail, nnml (Gnus) and evolution)
 .IP *
 mbox (including mboxes that have been compressed with gzip or bzip2)
+.IP *
+IMAP: remote folders on an IMAP server
 .PP
 If maildir or MH source folders are used, and a search outputs its matches to
 an mfolder in maildir or MH format, symbolic links are used to reference the
 original messages inside the mfolder.  However, if mbox folders are involved,
-copies of messages are made instead.
-
+copies of messages are made instead. If IMAP folders are used for both source
+results, IMAP server-side copies of messages are made. With IMAP source folders
+and any other type of results folder, messages are downloaded from the IMAP
+server to be written to the results folder. With an IMAP results folder and
+any other type of source folders, messages are uploaded to the IMAP server
+to be appended to the results folder.
 .SH OPTIONS
 
 .B mairix
@@ -233,7 +239,8 @@ paths on stdout.
 .br
 Instead of creating an mfolder containing the matched messages, display an
 excerpt from their headers on stdout.  The excerpt shows To, Cc, From, Subject
-and Date.
+and Date. With IMAP source folders, this requires downloading each matched
+message from the IMAP server.
 
 .TP
 .B -H, --force-hardlinks

--- a/mairix.c
+++ b/mairix.c
@@ -286,7 +286,7 @@ static int check_message_list_for_duplicates(struct msgpath_array *msgs)/*{{{*/
   n = msgs->n;
   sorted_paths = new_array(char *, n);
   for (i=0, nn=0; i<n; i++) {
-    switch (msgs->type[i]) {
+    switch (msgs->paths[i].type) {
       case MTY_MBOX:
         break;
       case MTY_DEAD:

--- a/mairix.c
+++ b/mairix.c
@@ -748,7 +748,7 @@ int main (int argc, char **argv)/*{{{*/
           database_path);
       unlock_and_exit(3);
     }
-    result = search_top(do_threads, do_augment, database_path, complete_mfolder, argv, output_folder_type, verbose);
+    result = search_top(do_threads, do_augment, database_path, complete_mfolder, argv, output_folder_type, verbose, imap_pipe, imap_server, imap_username, imap_password);
 
   } else {
     enum filetype ftype;

--- a/mairix.c
+++ b/mairix.c
@@ -269,6 +269,23 @@ static void parse_rc_file(char *name)/*{{{*/
   if (used_default_name) free(name);
 }
 /*}}}*/
+
+static int message_compare(const void *a, const void *b)/*{{{*/
+{
+  /* FIXME : Is this a sensible way to do this with mbox messages in the picture? */
+  struct msgpath *aa = (struct msgpath *) a;
+  struct msgpath *bb = (struct msgpath *) b;
+  if (aa->type < bb->type) return -1;
+  if (aa->type > bb->type) return 1;
+  return strcmp(aa->src.mpf.path, bb->src.mpf.path);
+}
+/*}}}*/
+static void sort_message_list(struct msgpath_array *arr)/*{{{*/
+{
+  qsort(arr->paths, arr->n, sizeof(struct msgpath), message_compare);
+}
+/*}}}*/
+
 static int compare_strings(const void *a, const void *b)/*{{{*/
 {
   const char **aa = (const char **) a;
@@ -725,6 +742,7 @@ int main (int argc, char **argv)/*{{{*/
     if (mh_folders) {
       build_message_list(folder_base, mh_folders, FT_MH, msgs, omit_globs);
     }
+    sort_message_list(msgs);
 
     /* The next call sorts the msgs array as part of looking for duplicates. */
     if (check_message_list_for_duplicates(msgs)) {

--- a/mairix.h
+++ b/mairix.h
@@ -351,7 +351,8 @@ struct database *new_database_from_file(char *db_filename, int do_integrity_chec
 void free_database(struct database *db);
 void maybe_grow_message_arrays(struct database *db);
 void tokenise_message(int file_index, struct database *db, struct rfc822 *msg);
-int update_database(struct database *db, struct msgpath *sorted_paths, int n_paths, int do_fast_index);
+struct imap_ll;
+int update_database(struct database *db, struct msgpath *sorted_paths, int n_paths, int do_fast_index, struct imap_ll *);
 void check_database_integrity(struct database *db);
 int cull_dead_messages(struct database *db, int do_integrity_checks);
 

--- a/mairix.h
+++ b/mairix.h
@@ -378,7 +378,7 @@ int is_glob_match(struct globber *g, const char *s);
 void write_database(struct database *db, char *filename, int do_integrity_checks);
 
 /* In search.c */
-int search_top(int do_threads, int do_augment, char *database_path, char *complete_mfolder, char **argv, enum folder_type ft, int verbose);
+int search_top(int do_threads, int do_augment, char *database_path, char *complete_mfolder, char **argv, enum folder_type ft, int verbose, const char *imap_pipe, const char *imap_server, const char *imap_username, const char *imap_password);
 
 /* In stats.c */
 void get_db_stats(struct database *db);

--- a/mairix.h
+++ b/mairix.h
@@ -33,9 +33,16 @@
 
 #include "memmac.h"
 
+enum message_type {/*{{{*/
+  MTY_DEAD,     /* msg no longer exists, i.e. don't report in searches,
+                   prune it on a '-p' run. */
+  MTY_FILE,     /* msg <-> file in 1-1 correspondence e.g. maildir, MH */
+  MTY_MBOX      /* multiple msgs per file : MBOX format file */
+};
+/*}}}*/
+
 struct msgpath {/*{{{*/
-  /* The 'selector' for this union is the corresponding entry of type 'enum
-   * message_type' */
+  enum message_type type; /* selector for union 'src' */
   union {
     struct {
       char *path;
@@ -61,15 +68,7 @@ struct msgpath {/*{{{*/
 };
 /*}}}*/
 
-enum message_type {/*{{{*/
-  MTY_DEAD,     /* msg no longer exists, i.e. don't report in searches,
-                   prune it on a '-p' run. */
-  MTY_FILE,     /* msg <-> file in 1-1 correspondence e.g. maildir, MH */
-  MTY_MBOX      /* multiple msgs per file : MBOX format file */
-};
-/*}}}*/
 struct msgpath_array {/*{{{*/
-  enum message_type *type;
   struct msgpath *paths;
   int n;
   int max;

--- a/mairix.h
+++ b/mairix.h
@@ -248,7 +248,8 @@ enum folder_type {/*{{{*/
   FT_MH,
   FT_MBOX,
   FT_RAW,
-  FT_EXCERPT
+  FT_EXCERPT,
+  FT_IMAP
 };
 /*}}}*/
 

--- a/mairix.h
+++ b/mairix.h
@@ -37,7 +37,8 @@ enum message_type {/*{{{*/
   MTY_DEAD,     /* msg no longer exists, i.e. don't report in searches,
                    prune it on a '-p' run. */
   MTY_FILE,     /* msg <-> file in 1-1 correspondence e.g. maildir, MH */
-  MTY_MBOX      /* multiple msgs per file : MBOX format file */
+  MTY_MBOX,     /* multiple msgs per file : MBOX format file */
+  MTY_IMAP	/* Message on IMAP server; syntax: uidvalidity:uid:folder */
 };
 /*}}}*/
 

--- a/mairixrc.5
+++ b/mairixrc.5
@@ -61,6 +61,41 @@ If the path is relative, it is treated as relative to the location of the
 file.
 
 .TP
+.BI imap_server= hostname
+.br
+If any IMAP source folders are specified or the results folder is an IMAP
+folder, this defines the host name of the IMAP server. The port is
+currently always 143. This option is mutually exclusive with the
+'imap_pipe' option.
+
+.TP
+.BI imap_pipe= shell-command
+.br
+If any IMAP source folders are specified or the results folder is an IMAP
+folder, this defines a shell command that can be used to connect to the
+IMAP server and talk to it over UNIX pipes instead of a TCP/IP connection.
+This option is mutually exclusive with the 'imap_server' option.
+
+.TP
+.BI imap_username= username
+.br
+If any IMAP source folders are specified or the results folder is an IMAP
+folder, this defines the user name to use to log in to the IMAP server.
+This parameter is optional, but IMAP servers normally require clients to
+log in, so it is normally necessary to specify it. One example of a case
+where it is not required is if the 'imap_pipe' option is in use the the
+shell command established a connection with an IMAP server in
+pre-autenticated state.
+
+.TP
+.BI imap_password= password
+.br
+If any IMAP source folders are specified or the results folder is an IMAP
+folder, this defines the password to use to log in to the IMAP server.
+This parameter is optional, but IMAP servers normally require clients to
+log in, so it is normally necessary to specify it.
+
+.TP
 .BI maildir= list-of-folder-specifications
 This is a colon-separated list of the Maildir folders (relative to
 `base') that you want indexed.  Any entry that ends `...' is
@@ -245,6 +280,20 @@ can support a maximum of 65536 separate mboxes, and a
 maximum of 65536 messages within any one mbox.
 
 .TP
+.BI imap= list-of-folders
+.br
+This is a colon-separated list of the IMAP folders that you want indexed.
+
+These folders must all be located on the same account on the same IMAP
+server. The configuration options imap_server and imap_pipe specify
+how to connect to the IMAP server.
+
+More than one line starting with 'imap' can be included.  In this
+case, 
+.B mairix
+joins the lines together with colons as though a
+single list of folders had been given on a single very long line.
+.TP
 .BI omit= list-of-glob-patterns
 This is a colon-separated list of glob patterns for folders to be omitted from
 the indexing.  This allows wide wildcards and recursive elements to be used
@@ -321,9 +370,9 @@ folders.
 .TP
 .BI mformat= format
 This defines the type of folder used for the match folder where
-the search results go.  There are four valid settings for
+the search results go.  There are six valid settings for
 .IR format ,
-namely 'maildir', 'mh', 'mbox', 'raw' or 'excerpt'.  If the 'raw' setting is
+namely 'maildir', 'mh', 'mbox', 'imap', 'raw', or 'excerpt'.  If the 'raw' setting is
 used then
 .B mairix
 will just print out the path names of the files that match and no match folder

--- a/reader.h
+++ b/reader.h
@@ -116,6 +116,8 @@
 #define DB_MSG_FILE 1
 /* mbox : multiple files per message */
 #define DB_MSG_MBOX 2
+/* message comes from IMAP server */
+#define DB_MSG_IMAP 3
 /*}}}*/
 
 #define FLAG_SEEN    (1<<3)

--- a/rfc822.c
+++ b/rfc822.c
@@ -1017,13 +1017,13 @@ struct rfc822 *data_to_rfc822(struct msg_src *src,
   /* Extract key headers {{{*/
   ct_nvp = cte_nvp = cd_nvp = NULL;
   for (x=header.next; x!=&header; x=x->next) {
-    if      (match_string("to", x->text))
+    if      (match_string("to:", x->text))
       copy_or_concat_header_value(&result->hdrs.to, x->text);
-    else if (match_string("cc", x->text))
+    else if (match_string("cc:", x->text))
       copy_or_concat_header_value(&result->hdrs.cc, x->text);
-    else if (!result->hdrs.from && match_string("from", x->text))
+    else if (!result->hdrs.from && match_string("from:", x->text))
       result->hdrs.from = copy_header_value(x->text);
-    else if (!result->hdrs.subject && match_string("subject", x->text))
+    else if (!result->hdrs.subject && match_string("subject:", x->text))
       result->hdrs.subject = copy_header_value(x->text);
     else if (!ct_nvp && (nvp = make_nvp(src, x->text, "content-type:")))
       ct_nvp = nvp;
@@ -1031,19 +1031,19 @@ struct rfc822 *data_to_rfc822(struct msg_src *src,
       cte_nvp = nvp;
     else if (!cd_nvp && (nvp = make_nvp(src, x->text, "content-disposition:")))
       cd_nvp = nvp;
-    else if (!result->hdrs.date && match_string("date", x->text)) {
+    else if (!result->hdrs.date && match_string("date:", x->text)) {
       char *date_string = copy_header_value(x->text);
       result->hdrs.date = parse_rfc822_date(date_string);
       free(date_string);
-    } else if (!result->hdrs.message_id && match_string("message-id", x->text))
+    } else if (!result->hdrs.message_id && match_string("message-id:", x->text))
       result->hdrs.message_id = copy_header_value(x->text);
-    else if (!result->hdrs.in_reply_to && match_string("in-reply-to", x->text))
+    else if (!result->hdrs.in_reply_to && match_string("in-reply-to:", x->text))
       result->hdrs.in_reply_to = copy_header_value(x->text);
-    else if (!result->hdrs.references && match_string("references", x->text))
+    else if (!result->hdrs.references && match_string("references:", x->text))
       result->hdrs.references = copy_header_value(x->text);
-    else if (match_string("status", x->text))
+    else if (match_string("status:", x->text))
       scan_status_flags(x->text + sizeof("status:"), &result->hdrs);
-    else if (match_string("x-status", x->text))
+    else if (match_string("x-status:", x->text))
       scan_status_flags(x->text + sizeof("x-status:"), &result->hdrs);
   }
 /*}}}*/

--- a/rfc822.c
+++ b/rfc822.c
@@ -881,7 +881,10 @@ static void do_multipart(struct msg_src *src,
       boundary_ok = 1;
       if ((b1 > input) && (*(b1-1) != '\n'))
         boundary_ok = 0;
-      if (!looking_at_end_boundary && (b1 + boundary_len + 2 < input + input_len) && (*(b1 + boundary_len + 2) != '\n'))
+      if (!looking_at_end_boundary && !(
+          ((b1 + boundary_len + 2 < input + input_len) && (*(b1 + boundary_len + 2) == '\n')) ||
+          ((b1 + boundary_len + 3 < input + input_len) && (*(b1 + boundary_len + 2) == '\r') && (*(b1 + boundary_len + 3) == '\n'))
+      ))
         boundary_ok = 0;
       if (!boundary_ok) {
         char *eol = strchr(b1, '\n');

--- a/writer.c
+++ b/writer.c
@@ -179,6 +179,7 @@ static int char_length(struct database *db)/*{{{*/
       case MTY_MBOX:
         break;
       case MTY_FILE:
+      case MTY_IMAP:
         assert(db->msgs[i].src.mpf.path);
         result += (1 + strlen(db->msgs[i].src.mpf.path));
         break;
@@ -322,6 +323,9 @@ static char *write_type_and_flag_table(struct database *db, unsigned int *uidata
       case MTY_DEAD:
         cdata[i] = DB_MSG_DEAD;
         break;
+      case MTY_IMAP:
+        cdata[i] = DB_MSG_IMAP;
+        break;
     }
 
     if (msgdata->seen)    cdata[i] |= FLAG_SEEN;
@@ -345,6 +349,14 @@ static char *write_messages(struct database *db, struct write_map *map, unsigned
         uidata[map->path_offset + i] = cdata - data;
         uidata[map->mtime_offset + i] = db->msgs[i].src.mpf.mtime;
         uidata[map->size_offset + i] = db->msgs[i].src.mpf.size;
+        uidata[map->date_offset + i] = db->msgs[i].date;
+        uidata[map->tid_offset + i]  = db->msgs[i].tid;
+        memcpy(cdata, db->msgs[i].src.mpf.path, 1 + slen); /* include trailing null */
+        cdata += (1 + slen);
+        break;
+      case MTY_IMAP:
+        slen = strlen(db->msgs[i].src.mpf.path);
+        uidata[map->path_offset + i] = cdata - data;
         uidata[map->date_offset + i] = db->msgs[i].date;
         uidata[map->tid_offset + i]  = db->msgs[i].tid;
         memcpy(cdata, db->msgs[i].src.mpf.path, 1 + slen); /* include trailing null */


### PR DESCRIPTION
http://sourceforge.net/p/mairix/mailman/mairix-users/thread/5409CDCE.6000803%40TZoNE.ORG/#msg32800160

I have added an IMAP client to mairix so that it supports indexing and searching messages found on an IMAP server and placing search results in a folder on the same IMAP server. Both features are optional, so that you can also index remote messages and store the results locally, or index local folders and store the results on IMAP.

My changes are made up of about 8 patches.
