### PR TITLE
Support for large mailboxes

### DIFF
--- a/mairix.h
+++ b/mairix.h
@@ -327,9 +327,9 @@ enum data_to_rfc822_error {
   DTR8_BAD_HEADERS, /* corrupt headers */
   DTR8_BAD_ATTACHMENT /* corrupt attachment (e.g. no body part) */
 };
-struct rfc822 *data_to_rfc822(struct msg_src *src, char *data, int length, enum data_to_rfc822_error *error);
-void create_ro_mapping(const char *filename, unsigned char **data, int *len);
-void free_ro_mapping(unsigned char *data, int len);
+struct rfc822 *data_to_rfc822(struct msg_src *src, char *data, long length, enum data_to_rfc822_error *error);
+void create_ro_mapping(const char *filename, unsigned char **data, size_t *len);
+void free_ro_mapping(unsigned char *data, size_t len);
 char *format_msg_src(struct msg_src *src);
 
 /* In tok.c */

--- a/mbox.c
+++ b/mbox.c
@@ -816,7 +816,7 @@ void build_mbox_lists(struct database *db, const char *folder_base, /*{{{*/
         mb->n_old_msgs_valid = mb->n_msgs;
       } else {
         unsigned char *va;
-        int len;
+        size_t len;
         create_ro_mapping(mb->path, &va, &len);
         if (va) {
           rescan_mbox(mb, (char *) va, len);
@@ -852,7 +852,7 @@ int add_mbox_messages(struct database *db)/*{{{*/
   int any_new = 0;
   int N;
   unsigned char *va;
-  int valen;
+  size_t valen;
   enum data_to_rfc822_error error;
 
   for (i=0; i<db->n_mboxen; i++) {

--- a/search.c
+++ b/search.c
@@ -681,7 +681,7 @@ static void mbox_terminate(const unsigned char *data, int len, FILE *out)/*{{{*/
 static void append_file_to_mbox(const char *path, FILE *out)/*{{{*/
 {
   unsigned char *data;
-  int len;
+  size_t len;
   create_ro_mapping(path, &data, &len);
   if (data) {
     fprintf(out, "From mairix@mairix Mon Jan  1 12:34:56 1970\n");
@@ -698,7 +698,7 @@ static int had_failed_checksum;
 
 static void get_validated_mbox_msg(struct read_db *db, int msg_index,/*{{{*/
                                    int *mbox_index,
-                                   unsigned char **mbox_data, int *mbox_len,
+                                   unsigned char **mbox_data, size_t *mbox_len,
                                    unsigned char **msg_data,  int *msg_len)
 {
   /* msg_data==NULL if checksum mismatches */
@@ -738,7 +738,8 @@ static void append_mboxmsg_to_mbox(struct read_db *db, int msg_index, FILE *out)
 {
   /* Need to common up code with try_copy_to_path */
   unsigned char *mbox_start, *msg_start;
-  int mbox_len, msg_len;
+  size_t mbox_len;
+  int msg_len;
   int mbox_index;
 
   get_validated_mbox_msg(db, msg_index, &mbox_index, &mbox_start, &mbox_len, &msg_start, &msg_len);
@@ -759,7 +760,8 @@ static void append_mboxmsg_to_mbox(struct read_db *db, int msg_index, FILE *out)
 static void try_copy_to_path(struct read_db *db, int msg_index, char *target_path)/*{{{*/
 {
   unsigned char *data;
-  int mbox_len, msg_len;
+  size_t mbox_len;
+  int msg_len;
   int mbi;
   FILE *out;
   unsigned char *start;
@@ -1214,7 +1216,8 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
                 unsigned int mbix, msgix;
                 int start, len, after_end;
                 unsigned char *mbox_start, *msg_start;
-                int mbox_len, msg_len;
+                size_t mbox_len;
+                int msg_len;
                 int mbox_index;
 
                 start = db->mtime_table[i];


### PR DESCRIPTION
This patch fixes a problem that appears when large mailboxes are used:

    rfc822:mmap '/path/to/mbox': Cannot allocate memory
