### PR TITLE
Option to follow symlinks to mboxes in rc file

### DIFF
--- a/mairix.c
+++ b/mairix.c
@@ -51,6 +51,7 @@ static char *omit = NULL;
 static char *database_path = NULL;
 static enum folder_type output_folder_type = FT_MAILDIR;
 static int skip_integrity_checks = 0;
+static int follow_mbox_symlinks = 0;
 
 enum filetype {
   M_NONE, M_FILE, M_DIR, M_OTHER
@@ -249,6 +250,7 @@ static void parse_rc_file(char *name)/*{{{*/
     }
     else if (!strncasecmp(p, "mh=", 3)) add_folders(&mh_folders, copy_value(p));
     else if (!strncasecmp(p, "mbox=", 5)) add_folders(&mboxen, copy_value(p));
+    else if (!strncasecmp(p, "follow_mbox_symlinks", 20)) follow_mbox_symlinks = 1;
     else if (!strncasecmp(p, "omit=", 5)) add_folders(&omit, copy_value(p));
 
     else if (!strncasecmp(p, "mformat=", 8)) {
@@ -490,6 +492,7 @@ int main (int argc, char **argv)/*{{{*/
   int do_integrity_checks = 1;
   int do_forced_unlock = 0;
   int do_fast_index = 0;
+  int do_mbox_symlinks = 0;
 
   unsigned int forced_hash_key = CREATE_RANDOM_DATABASE_HASH;
 
@@ -615,6 +618,10 @@ int main (int argc, char **argv)/*{{{*/
 
   if (skip_integrity_checks) {
     do_integrity_checks = 0;
+  }
+
+  if (follow_mbox_symlinks) {
+    do_mbox_symlinks = 1;
   }
 
   if (!folder_base) {
@@ -746,7 +753,7 @@ int main (int argc, char **argv)/*{{{*/
       unlock_and_exit(2);
     }
 
-    build_mbox_lists(db, folder_base, mboxen, omit_globs);
+    build_mbox_lists(db, folder_base, mboxen, omit_globs, do_mbox_symlinks);
 
     any_updates = update_database(db, msgs->paths, msgs->n, do_fast_index);
     if (do_purge) {

--- a/mairix.h
+++ b/mairix.h
@@ -357,7 +357,8 @@ int cull_dead_messages(struct database *db, int do_integrity_checks);
 
 /* In mbox.c */
 void build_mbox_lists(struct database *db, const char *folder_base,
-    const char *mboxen_paths, struct globber_array *omit_globs);
+    const char *mboxen_paths, struct globber_array *omit_globs,
+    int do_mbox_symlinks);
 int add_mbox_messages(struct database *db);
 void compute_checksum(const char *data, size_t len, checksum_t *csum);
 void cull_dead_mboxen(struct database *db);

--- a/mairixrc.5
+++ b/mairixrc.5
@@ -358,6 +358,12 @@ relative to the location of the
 .I mairixrc
 file or anything like that.)
 
+.TP
+.BI follow_mbox_symlinks
+.br
+By default, mairix will skip symlinks to mboxes when indexing.  This
+option causes causes mairix to follow them instead of skipping them.
+
 .SS Expansions
 
 The part of each line in '.mairixrc' following the equals sign can

--- a/mairixrc.5
+++ b/mairixrc.5
@@ -361,8 +361,10 @@ file or anything like that.)
 .TP
 .BI follow_mbox_symlinks
 .br
-By default, mairix will skip symlinks to mboxes when indexing.  This
-option causes causes mairix to follow them instead of skipping them.
+This takes no arguments.  By default, mairix will skip symlinks to
+mboxes when indexing.  If a line starting with
+.B follow_mbox_symlinks
+is present, mairix will follow them instead of skipping them.
 
 .SS Expansions
 

--- a/mbox.c
+++ b/mbox.c
@@ -743,7 +743,8 @@ void glob_and_expand_paths(const char *folder_base,
 /*}}}*/
 
 void build_mbox_lists(struct database *db, const char *folder_base, /*{{{*/
-    const char *mboxen_paths, struct globber_array *omit_globs)
+    const char *mboxen_paths, struct globber_array *omit_globs,
+    int do_mbox_symlinks)
 {
   char **raw_paths, **paths;
   int n_raw_paths, i;
@@ -776,8 +777,8 @@ void build_mbox_lists(struct database *db, const char *folder_base, /*{{{*/
     if (lstat(path, &sb) < 0) {
       /* can't stat */
     } else {
-      if (S_ISLNK(sb.st_mode)) {
-        /* Skip mbox if symlink */
+      if (S_ISLNK(sb.st_mode) && !do_mbox_symlinks) {
+        /* Skip mbox if symlink and no follow_mbox_symlinks in mairixrc */
         if (verbose) {
           printf("%s is a link - skipping\n", path);
         }


### PR DESCRIPTION
Add `.mairixrc` option `follow_mbox_symlinks` which allows the user to restore the behaviour disabled by commit 74ebca5.

This is particularly useful for users of git-annex.  It is [possible to work around mairix's symlink-skipping behaviour](https://joeyh.name/blog/entry/moving_my_email_archives_and_packages_to_git-annex/), but a simple configuration file option to restore the old behaviour is much more practical.

This patch does not change the default behaviour of mairix for users who do not explicitly include `follow_mbox_symlinks` in their `.mairixrc`.
